### PR TITLE
Use WebApi for Response construction

### DIFF
--- a/app/entry.server.res
+++ b/app/entry.server.res
@@ -1,14 +1,4 @@
-module ResponseInit = {
-  type t
-
-  external make: {..} => t = "%identity"
-}
-
-// TODO: Swap out for Webapi.Fetch.Response when it supports construction
-// See https://github.com/tinymce/rescript-webapi/issues/63
-@new
-external makeResponse: (Webapi.Fetch.BodyInit.t, ResponseInit.t) => Webapi.Fetch.Response.t =
-  "Response"
+external castHeadersToInit: Webapi.Fetch.Headers.t => Webapi.Fetch.HeadersInit.t = "%identity"
 
 let default = (request, responseStatusCode, responseHeaders, remixContext) => {
   open Webapi
@@ -19,11 +9,12 @@ let default = (request, responseStatusCode, responseHeaders, remixContext) => {
 
   responseHeaders->Fetch.Headers.set("Content-Type", "text/html")
 
-  makeResponse(
-    Fetch.BodyInit.make("<!DOCTYPE html>" ++ markup),
-    ResponseInit.make({
-      "status": responseStatusCode,
-      "headers": responseHeaders,
-    }),
+  Fetch.Response.makeWithInit(
+    "<!DOCTYPE html>" ++ markup,
+    Fetch.ResponseInit.make(
+      ~status=responseStatusCode,
+      ~headers=responseHeaders->castHeadersToInit,
+      (),
+    ),
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "remix": "^1.1.1",
-        "rescript-webapi": "^0.2.0"
+        "rescript-webapi": "^0.3.0"
       },
       "devDependencies": {
         "@remix-run/dev": "^1.1.1",
@@ -4720,9 +4720,9 @@
       }
     },
     "node_modules/rescript-webapi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rescript-webapi/-/rescript-webapi-0.2.0.tgz",
-      "integrity": "sha512-SzWON5edviVG1mtHvrUR6UZIpDqSY/nYVkl9F92zFxXhZ+VAdmiJtYoHZTRJ9DSgaslcyY4c9ZlymRqyWZ7eEA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rescript-webapi/-/rescript-webapi-0.3.0.tgz",
+      "integrity": "sha512-MhcnQS94YvJ02oXcFYqSI0QKgjPqRcdc06VphcKrh8BlnWJaF5Kcqnhp5N6Jz9Fh6uKUeir0+Rfmq5421azk5w=="
     },
     "node_modules/resolve": {
       "version": "1.20.0",
@@ -9003,9 +9003,9 @@
       "dev": true
     },
     "rescript-webapi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rescript-webapi/-/rescript-webapi-0.2.0.tgz",
-      "integrity": "sha512-SzWON5edviVG1mtHvrUR6UZIpDqSY/nYVkl9F92zFxXhZ+VAdmiJtYoHZTRJ9DSgaslcyY4c9ZlymRqyWZ7eEA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rescript-webapi/-/rescript-webapi-0.3.0.tgz",
+      "integrity": "sha512-MhcnQS94YvJ02oXcFYqSI0QKgjPqRcdc06VphcKrh8BlnWJaF5Kcqnhp5N6Jz9Fh6uKUeir0+Rfmq5421azk5w=="
     },
     "resolve": {
       "version": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "remix": "^1.1.1",
-    "rescript-webapi": "^0.2.0"
+    "rescript-webapi": "^0.3.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.1.1",

--- a/remix.config.js
+++ b/remix.config.js
@@ -8,5 +8,5 @@ module.exports = {
   serverBuildDirectory: "build",
   devServerPort: 8002,
   ignoredRouteFiles: [".*", "*.res"],
-  transpileModules: ["rescript"]
+  transpileModules: ["rescript", "rescript-webapi"]
 };


### PR DESCRIPTION
Not merging for now as I'm not happy about the cast. It's unsafe in all situations apart from the fetch API where things accept either `HeadersInit.t` or `Headers.t`.

I've raised an issue about this in the bindings, let's wait to see what the resolution is: https://github.com/tinymce/rescript-webapi/issues/70
